### PR TITLE
feature/pwm-chip-by-name

### DIFF
--- a/examples/breathe.rs
+++ b/examples/breathe.rs
@@ -19,12 +19,14 @@ const BB_PWM_NUMBER: u32 = 0;
 fn pwm_increase_to_max(pwm: &Pwm,
                        duration_ms: u32,
                        update_period_ms: u32) -> Result<()> {
-    let step: f32 = duration_ms as f32 / update_period_ms as f32;
+    let num_steps: f32 = duration_ms as f32 / update_period_ms as f32;
+    let step = 1.0 / num_steps;
     let mut duty_cycle = 0.0;
-    let period_ns: u32 = try!(pwm.get_period_ns());
+    let period_ns: u32 = pwm.get_period_ns()?;
     while duty_cycle < 1.0 {
-        try!(pwm.set_duty_cycle_ns((duty_cycle * period_ns as f32) as u32));
+        pwm.set_duty_cycle_ns((duty_cycle * period_ns as f32) as u32)?;
         duty_cycle += step;
+        std::thread::sleep(std::time::Duration::from_millis(update_period_ms as u64))
     }
     pwm.set_duty_cycle_ns(period_ns)
 }
@@ -32,12 +34,14 @@ fn pwm_increase_to_max(pwm: &Pwm,
 fn pwm_decrease_to_minimum(pwm: &Pwm,
                            duration_ms: u32,
                            update_period_ms: u32) -> Result<()> {
-    let step: f32 = duration_ms as f32 / update_period_ms as f32;
+    let num_steps: f32 = duration_ms as f32 / update_period_ms as f32;
+    let step = 1.0 / num_steps;
     let mut duty_cycle = 1.0;
-    let period_ns: u32 = try!(pwm.get_period_ns());
+    let period_ns: u32 = pwm.get_period_ns()?;
     while duty_cycle > 0.0 {
-        try!(pwm.set_duty_cycle_ns((duty_cycle * period_ns as f32) as u32));
+        pwm.set_duty_cycle_ns((duty_cycle * period_ns as f32) as u32)?;
         duty_cycle -= step;
+        std::thread::sleep(std::time::Duration::from_millis(update_period_ms as u64))
     }
     pwm.set_duty_cycle_ns(0)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,6 @@
 // Portions of this implementation are based on work by Nat Pryce:
 // https://github.com/npryce/rusty-pi/blob/master/src/pi/gpio.rs
 
-use std::convert;
 use std::fmt;
 use std::io;
 
@@ -21,7 +20,7 @@ pub enum Error {
     Unexpected(String),
 }
 
-impl ::std::error::Error for Error {
+impl std::error::Error for Error {
     fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match *self {
             Error::Io(ref e) => Some(e),
@@ -40,7 +39,7 @@ impl fmt::Display for Error {
 }
 
 
-impl convert::From<io::Error> for Error {
+impl From<io::Error> for Error {
     fn from(e: io::Error) -> Error {
         Error::Io(e)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,14 +22,7 @@ pub enum Error {
 }
 
 impl ::std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref e) => e.description(),
-            Error::Unexpected(_) => "something unexpected",
-        }
-    }
-
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match *self {
             Error::Io(ref e) => Some(e),
             _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub enum Polarity {
     Inverse,
 }
 
-pub type Result<T> = ::std::result::Result<T, error::Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// Open the specified entry name as a writable file
 fn pwm_file_wo(chip: &PwmChip, pin: u32, name: &str) -> Result<File> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,25 +45,25 @@ pub type Result<T> = ::std::result::Result<T, error::Error>;
 
 /// Open the specified entry name as a writable file
 fn pwm_file_wo(chip: &PwmChip, pin: u32, name: &str) -> Result<File> {
-    let f = try!(OpenOptions::new().write(true)
-                 .open(format!("/sys/class/pwm/pwmchip{}/pwm{}/{}",
-                               chip.number,
-                               pin,
-                               name)));
+    let f = OpenOptions::new().write(true)
+        .open(format!("/sys/class/pwm/pwmchip{}/pwm{}/{}",
+                      chip.number,
+                      pin,
+                      name))?;
     Ok(f)
 }
 
 /// Open the specified entry name as a readable file
 fn pwm_file_ro(chip: &PwmChip, pin: u32, name: &str) -> Result<File> {
-    let f = try!(File::open(format!("/sys/class/pwm/pwmchip{}/pwm{}/{}", chip.number, pin, name)));
+    let f = File::open(format!("/sys/class/pwm/pwmchip{}/pwm{}/{}", chip.number, pin, name))?;
     Ok(f)
 }
 
 /// Get the u32 value from the given entry
 fn pwm_file_parse<T: FromStr>(chip: &PwmChip, pin: u32, name: &str) -> Result<T> {
     let mut s = String::with_capacity(10);
-    let mut f = try!(pwm_file_ro(chip, pin, name));
-    try!(f.read_to_string(&mut s));
+    let mut f = pwm_file_ro(chip, pin, name)?;
+    f.read_to_string(&mut s)?;
     match s.trim().parse::<T>() {
         Ok(r) => Ok(r),
         Err(_) => Err(Error::Unexpected(format!("Unexpeted value file contents: {:?}", s))),
@@ -73,15 +73,15 @@ fn pwm_file_parse<T: FromStr>(chip: &PwmChip, pin: u32, name: &str) -> Result<T>
 
 impl PwmChip {
     pub fn new(number: u32) -> Result<PwmChip> {
-        try!(fs::metadata(&format!("/sys/class/pwm/pwmchip{}", number)));
-        Ok(PwmChip { number: number })
+        fs::metadata(format!("/sys/class/pwm/pwmchip{}", number))?;
+        Ok(PwmChip { number })
     }
 
     pub fn count(&self) -> Result<u32> {
         let npwm_path = format!("/sys/class/pwm/pwmchip{}/npwm", self.number);
-        let mut npwm_file = try!(File::open(&npwm_path));
+        let mut npwm_file = File::open(&npwm_path)?;
         let mut s = String::new();
-        try!(npwm_file.read_to_string(&mut s));
+        npwm_file.read_to_string(&mut s)?;
         match s.parse::<u32>() {
             Ok(n) => Ok(n),
             Err(_) => Err(Error::Unexpected(format!("Unexpected npwm contents: {:?}", s))),
@@ -90,22 +90,22 @@ impl PwmChip {
 
     pub fn export(&self, number: u32) -> Result<()> {
         // only export if not already exported
-        if let Err(_) = fs::metadata(&format!("/sys/class/pwm/pwmchip{}/pwm{}",
+        if fs::metadata(format!("/sys/class/pwm/pwmchip{}/pwm{}",
                                               self.number,
-                                              number)) {
+                                              number)).is_err() {
             let path = format!("/sys/class/pwm/pwmchip{}/export", self.number);
-            let mut export_file = try!(File::create(&path));
+            let mut export_file = File::create(&path)?;
             let _ = export_file.write_all(format!("{}", number).as_bytes());
         }
         Ok(())
     }
 
     pub fn unexport(&self, number: u32) -> Result<()> {
-        if let Ok(_) = fs::metadata(&format!("/sys/class/pwm/pwmchip{}/pwm{}",
+        if fs::metadata(format!("/sys/class/pwm/pwmchip{}/pwm{}",
                                              self.number,
-                                             number)) {
+                                             number)).is_ok() {
             let path = format!("/sys/class/pwm/pwmchip{}/unexport", self.number);
-            let mut export_file = try!(File::create(&path));
+            let mut export_file = File::create(&path)?;
             let _ = export_file.write_all(format!("{}", number).as_bytes());
         }
         Ok(())
@@ -117,10 +117,10 @@ impl Pwm {
     ///
     /// This function does not export the Pwm pin
     pub fn new(chip: u32, number: u32) -> Result<Pwm> {
-        let chip: PwmChip = try!(PwmChip::new(chip));
+        let chip: PwmChip = PwmChip::new(chip)?;
         Ok(Pwm {
-            chip: chip,
-            number: number,
+            chip,
+            number,
         })
     }
 
@@ -129,7 +129,7 @@ impl Pwm {
     pub fn with_exported<F>(&self, closure: F) -> Result<()>
         where F: FnOnce() -> Result<()>
     {
-        try!(self.export());
+        self.export()?;
         match closure() {
             Ok(()) => self.unexport(),
             Err(_) => self.unexport(),
@@ -148,13 +148,13 @@ impl Pwm {
 
     /// Enable/Disable the PWM Signal
     pub fn enable(&self, enable: bool) -> Result<()> {
-        let mut enable_file = try!(pwm_file_wo(&self.chip, self.number, "enable"));
+        let mut enable_file = pwm_file_wo(&self.chip, self.number, "enable")?;
         let contents = if enable {
             "1"
         } else {
             "0"
         };
-        try!(enable_file.write_all(contents.as_bytes()));
+        enable_file.write_all(contents.as_bytes())?;
         Ok(())
     }
 
@@ -168,8 +168,8 @@ impl Pwm {
     /// Value is in nanoseconds and must be less than the period.
     pub fn set_duty_cycle_ns(&self, duty_cycle_ns: u32) -> Result<()> {
         // we'll just let the kernel do the validation
-        let mut duty_cycle_file = try!(pwm_file_wo(&self.chip, self.number, "duty_cycle"));
-        try!(duty_cycle_file.write_all(format!("{}", duty_cycle_ns).as_bytes()));
+        let mut duty_cycle_file = pwm_file_wo(&self.chip, self.number, "duty_cycle")?;
+        duty_cycle_file.write_all(format!("{}", duty_cycle_ns).as_bytes())?;
         Ok(())
     }
 
@@ -180,8 +180,8 @@ impl Pwm {
 
     /// The period of the PWM signal in Nanoseconds
     pub fn set_period_ns(&self, period_ns: u32) -> Result<()> {
-        let mut period_file = try!(pwm_file_wo(&self.chip, self.number, "period"));
-        try!(period_file.write_all(format!("{}", period_ns).as_bytes()));
+        let mut period_file = pwm_file_wo(&self.chip, self.number, "period")?;
+        period_file.write_all(format!("{}", period_ns).as_bytes())?;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 //! PWM access under Linux using the PWM sysfs interface
 
 use std::io::prelude::*;
-use std::os::unix::prelude::*;
 use std::fs::File;
 use std::fs;
 use std::fs::OpenOptions;


### PR DESCRIPTION
Adds methods to instantiate chips by name, as they might get allocated dynamically